### PR TITLE
Fix: Optimizer initialization takes weight decay as parameter

### DIFF
--- a/engine/trainer.py
+++ b/engine/trainer.py
@@ -99,9 +99,9 @@ class Trainer:
             ]
 
         if self.config.optimizer_type == "sgd":
-            optimizer = torch.optim.SGD(optimizer_parameters, lr=self.config.optimizer_lr, momentum=self.config.optimizer_momentum,)
+            optimizer = torch.optim.SGD(optimizer_parameters, lr=self.config.optimizer_lr, momentum=self.config.optimizer_momentum, weight_decay=self.config.optimizer_weight_decay)
         elif self.config.optimizer_type == "adam":
-            optimizer = torch.optim.Adam(optimizer_parameters, lr=self.config.optimizer_lr, eps=1e-9)
+            optimizer = torch.optim.Adam(optimizer_parameters, lr=self.config.optimizer_lr, eps=1e-9, weight_decay=self.config.optimizer_weight_decay)
         else:
             raise NotImplementedError
         return optimizer


### PR DESCRIPTION
In the Trainer class at _prepare_optimizer function, Adam and SGD do not contain weight decay attribute.
https://github.com/ML4SCI/SYMBA_Pytorch/blob/8bc21123c8e3d27b0c6ac72f9a0acf6d49baa807/engine/trainer.py#L104

Changing `optimizer_weight_decay` in config will have no effect on training.

Fixed this!